### PR TITLE
Change info about Postgres

### DIFF
--- a/test/resources/postgres.yaml
+++ b/test/resources/postgres.yaml
@@ -1,19 +1,32 @@
-apiVersion: postgresql.dev4devs.com/v1alpha1
-kind: Database
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
 metadata:
-  name: mypostgres
+  name: postgres
 spec:
-  size: 1
-  databaseMemoryLimit: "512Mi"
-  databaseMemoryRequest: "128Mi"
-  databaseCpuLimit: "60m"
-  databaseCpu: "30m"
-  databaseStorageRequest: "1Gi"
-  image: "centos/postgresql-96-centos7"
-  databaseNameKeyEnvVar: "POSTGRESQL_DATABASE"
-  databasePasswordKeyEnvVar: "POSTGRESQL_PASSWORD"
-  databaseUserKeyEnvVar: "POSTGRESQL_USER"
-
-  databaseName: "example"
-  databasePassword: "transformations"
-  databaseUser: "camel-k-example"
+  users:
+    - databases:
+        - test
+        - example
+      name: postgresadmin
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+  postgresVersion: 13
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - "ReadWriteOnce"
+              resources:
+                requests:
+                  storage: 1Gi


### PR DESCRIPTION
 I noticed that the `PostgreSQL Operator by Dev4Ddevs.com` operator, which is used in transformations quickstart, is not available in any of the Catalog Sources[1] installed by default in OCP anymore. (It still can be added there when the user add operatorhub.io catalog into the cluster where the operator is [available](https://operatorhub.io/operator/postgresql-operator-dev4devs-com))
 
Due to that, I updated the quickstart to use PostgresDB from crunchydata which is available in `Certified`, Community` and `Marketplace` catalogs.
 

[1] :
 ```
oc get CatalogSource -n openshift-marketplace
NAME                  DISPLAY               TYPE   PUBLISHER   AGE
certified-operators   Certified Operators   grpc   Red Hat     6d23h
community-operators   Community Operators   grpc   Red Hat     6d23h
redhat-marketplace    Red Hat Marketplace   grpc   Red Hat     6d23h
redhat-operators      Red Hat Operators     grpc   Red Hat     6d23h
```